### PR TITLE
Add server status check

### DIFF
--- a/src/app/code/community/Smile/MageCache/Model/Engine/Varnish.php
+++ b/src/app/code/community/Smile/MageCache/Model/Engine/Varnish.php
@@ -253,4 +253,14 @@ class Smile_MageCache_Model_Engine_Varnish extends Smile_MageCache_Model_Engine_
 
         $response->setHeader(self::CACHE_HEADER_NAME, $headerValue);
     }
+
+    /**
+     * Returns the list of servers that couldn't be reached at init.
+     *
+     * @return array
+     */
+    public function getServersInError()
+    {
+        return $this->_getConnector()->getServersInError();
+    }
 }

--- a/src/app/code/community/Smile/MageCache/Model/Engine/Varnish/Connector/Connection/Mode.php
+++ b/src/app/code/community/Smile/MageCache/Model/Engine/Varnish/Connector/Connection/Mode.php
@@ -35,6 +35,10 @@ class Smile_MageCache_Model_Engine_Varnish_Connector_Connection_Mode
     {
         return array(
             array(
+                'value' => 'varnish5_socket',
+                'label' => Mage::helper('smile_magecache')->__('Varnish5: administrator socket')
+            ),
+            array(
                 'value' => 'varnish4_socket',
                 'label' => Mage::helper('smile_magecache')->__('Varnish4: administrator socket')
             ),

--- a/src/lib/Varnish/Connector/Connection/Varnish5/Socket.php
+++ b/src/lib/Varnish/Connector/Connection/Varnish5/Socket.php
@@ -21,7 +21,7 @@
  * @package   Varnish
  * @category  Varnish_Connector
  * @author    Smile <solution.magento@smile.fr>
- * @copyright 2016 Smile
+ * @copyright 2018 Smile
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
 */
 class Varnish_Connector_Connection_Varnish5_Socket extends Varnish_Connector_Connection_Varnish4_Socket

--- a/src/lib/Varnish/Connector/Connection/Varnish5/Socket.php
+++ b/src/lib/Varnish/Connector/Connection/Varnish5/Socket.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * MageCache
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade MageCache to newer
+ * versions in the future.
+ */
+
+/**
+ * Varnish administrator socket connection
+*
+ * @package   Varnish
+ * @category  Varnish_Connector
+ * @author    Smile <solution.magento@smile.fr>
+ * @copyright 2016 Smile
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*/
+class Varnish_Connector_Connection_Varnish5_Socket extends Varnish_Connector_Connection_Varnish4_Socket
+{
+    /**
+     * Purge pages by URL pattern
+     *
+     * @param string $pattern URL pattern
+     *
+     * @return void
+     */
+    public function purgeByUrl($pattern)
+    {
+        $this->_put('ban req.url ~ '.$pattern, true);
+    }
+}


### PR DESCRIPTION
Add check for server status to avoid failing to execute action if a server is in error. Servers in error are just store in class and process continue without them.
Add getter in Varnish model in Magento module to access the servers in error.